### PR TITLE
Bump loofah version in gemspec file

### DIFF
--- a/crazy_harry.gemspec
+++ b/crazy_harry.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '>=1.0.1'
   s.add_development_dependency 'simplecov',   '>=0.6.4'
 
-  s.add_runtime_dependency 'loofah',          '~>1'
+  s.add_runtime_dependency 'loofah',          '~>2'
   s.add_runtime_dependency 'nokogiri',        '>=1.5.5'
 
   s.add_dependency 'html_truncator',          '~>0.3'

--- a/lib/crazy_harry/version.rb
+++ b/lib/crazy_harry/version.rb
@@ -1,3 +1,3 @@
 module CrazyHarry
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Bumped due to `bundle install` failing in https://github.com/lonelyplanet/narrative_mappings